### PR TITLE
Revamp calendar interface

### DIFF
--- a/custom-tracker.html
+++ b/custom-tracker.html
@@ -48,6 +48,89 @@
             background: #f59e0b;
             border-radius: 50%;
         }
+
+        /* Enhanced Calendar Styles */
+        .calendar-day-enhanced {
+            position: relative;
+            aspect-ratio: 1;
+            border: 2px solid #e5e7eb;
+            border-radius: 16px;
+            display: flex;
+            flex-direction: column;
+            cursor: pointer;
+            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+            background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+            overflow: hidden;
+            min-height: 100px;
+        }
+
+        .calendar-day-enhanced:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 8px 25px rgba(0,0,0,0.15);
+            border-color: #3b82f6;
+        }
+
+        .calendar-day-enhanced.today {
+            border: 3px solid #3b82f6;
+            background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
+            box-shadow: 0 0 20px rgba(59, 130, 246, 0.3);
+        }
+
+        .calendar-day-enhanced.completed {
+            border-color: #10b981;
+            background: linear-gradient(135deg, #d1fae5 0%, #a7f3d0 100%);
+        }
+
+        .calendar-day-enhanced.scheduled {
+            border-color: #f59e0b;
+            background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+        }
+
+        .today-pulse {
+            position: absolute;
+            top: -2px;
+            right: -2px;
+            width: 8px;
+            height: 8px;
+            background: #3b82f6;
+            border-radius: 50%;
+            animation: pulse 2s infinite;
+        }
+
+        .completion-badge {
+            position: absolute;
+            top: 4px;
+            right: 4px;
+            font-size: 12px;
+            animation: bounce 1s infinite;
+        }
+
+        .workout-status {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 0.5rem;
+        }
+
+        .add-workout-hint {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            opacity: 0.7;
+        }
+
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+
+        @keyframes bounce {
+            0%, 20%, 50%, 80%, 100% { transform: translateY(0); }
+            40% { transform: translateY(-3px); }
+            60% { transform: translateY(-2px); }
+        }
         .modal-overlay {
             position: fixed;
             top: 0;
@@ -797,6 +880,334 @@
                 return '📋';
             }
 
+            // ===== Enhanced Features =====
+
+            calculateStreak() {
+                let streak = 0;
+                const today = new Date();
+
+                for (let i = 0; i < 30; i++) {
+                    const checkDate = new Date(today);
+                    checkDate.setDate(today.getDate() - i);
+                    const hasWorkout = this.hasWorkoutOnDate(checkDate);
+
+                    if (hasWorkout) {
+                        streak++;
+                    } else if (i > 0) {
+                        break;
+                    }
+                }
+
+                return streak;
+            }
+
+            hasWorkoutOnDate(date) {
+                const dateStr = date.toISOString().split('T')[0];
+                const weekString = this.getISOWeek(date);
+                const weekData = this.weeklyData.weeks[weekString];
+                return weekData?.workouts.some(w => w.date === dateStr && w.isCompleted);
+            }
+
+            getMonthStats() {
+                const month = new Date().toISOString().slice(0,7); // YYYY-MM
+                let total = 0;
+                Object.values(this.weeklyData.weeks).forEach(week => {
+                    week.workouts.forEach(w => {
+                        if (w.date.startsWith(month)) total++;
+                    });
+                });
+                return { total };
+            }
+
+            getPreviousWeek(weekString) {
+                const [year, week] = weekString.split('-W').map(Number);
+                const prevWeek = week - 1;
+                if (prevWeek <= 0) {
+                    return `${year - 1}-W52`;
+                }
+                return `${year}-W${String(prevWeek).padStart(2,'0')}`;
+            }
+
+            getNextWeek(weekString) {
+                const [year, week] = weekString.split('-W').map(Number);
+                const nextWeek = week + 1;
+                if (nextWeek > 52) {
+                    return `${year + 1}-W01`;
+                }
+                return `${year}-W${String(nextWeek).padStart(2,'0')}`;
+            }
+
+            getTodayWorkout() {
+                const todayStr = new Date().toISOString().split('T')[0];
+                return this.getWorkoutForDate(todayStr);
+            }
+
+            getLastWorkout() {
+                const weeks = Object.keys(this.weeklyData.weeks).sort().reverse();
+                for (const week of weeks) {
+                    const workouts = this.weeklyData.weeks[week].workouts.slice().reverse();
+                    const last = workouts.find(w => w.isCompleted);
+                    if (last) return last;
+                }
+                return null;
+            }
+
+            getEnhancedDayClass(workout, isToday, isPast) {
+                let classes = [];
+                if (isToday) classes.push('today');
+                if (workout?.isCompleted) classes.push('completed');
+                else if (workout) classes.push('scheduled');
+                if (isPast && !workout) classes.push('past');
+                return classes.join(' ');
+            }
+
+            renderEnhancedCalendarDays(currentWeek, weekData) {
+                const { start, end } = this.getWeekBounds(currentWeek);
+                const days = [];
+                const today = new Date().toISOString().split('T')[0];
+
+                for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+                    const dateStr = d.toISOString().split('T')[0];
+                    const workout = weekData.workouts.find(w => w.date === dateStr);
+                    const isToday = dateStr === today;
+                    const isPast = new Date(dateStr) < new Date().setHours(0,0,0,0);
+                    const dayName = d.toLocaleDateString('de-DE', {weekday: 'short'});
+
+                    days.push(`
+                      <div class="calendar-day-enhanced ${this.getEnhancedDayClass(workout, isToday, isPast)}" onclick="app.handleDayClick('${dateStr}')">
+                        <div class="day-header-enhanced">
+                          <div class="text-xs font-medium text-center mb-1">${dayName}</div>
+                          <div class="text-xl font-bold text-center mb-2">${d.getDate()}</div>
+                        </div>
+                        <div class="workout-status">
+                          ${workout ? `
+                            <div class="workout-indicator ${workout.isCompleted ? 'completed' : 'scheduled'}">
+                              ${workout.isCompleted ? '<div class="text-2xl">✅</div>' : '<div class="text-lg">💪</div>'}
+                            </div>
+                            <div class="workout-info">
+                              <div class="text-xs font-medium truncate">${workout.planDay}</div>
+                              <div class="text-xs text-gray-500">${workout.exercises.length} Übungen</div>
+                            </div>
+                          ` : isToday ? `
+                            <div class="add-workout-hint">
+                              <div class="text-xl opacity-60">➕</div>
+                              <div class="text-xs text-gray-500">Training hinzufügen</div>
+                            </div>
+                          ` : ''}
+                        </div>
+                        ${isToday ? '<div class="today-pulse"></div>' : ''}
+                        ${workout?.isCompleted ? '<div class="completion-badge">🔥</div>' : ''}
+                      </div>
+                    `);
+                }
+
+                return days.join('');
+            }
+
+            renderQuickActions(currentWeek, weekData) {
+                const todayWorkout = this.getTodayWorkout();
+
+                return `
+                    <div class="grid grid-cols-2 gap-3 mb-4">
+                      <div class="bg-gradient-to-br from-blue-500 to-indigo-600 rounded-2xl p-4 text-white shadow-lg">
+                        <div class="flex items-center justify-between mb-2">
+                          <h4 class="font-bold">Heute</h4>
+                          <div class="text-2xl">🏃‍♂️</div>
+                        </div>
+                        ${todayWorkout ? `
+                          <button onclick="app.startTodayWorkout()" class="w-full bg-white bg-opacity-20 rounded-lg py-2 px-3 text-sm font-semibold hover:bg-opacity-30 transition-colors">
+                            ${todayWorkout.isCompleted ? '👁️ Anzeigen' : '🚀 Starten'}
+                          </button>
+                        ` : `
+                          <button onclick="app.addTodayWorkout()" class="w-full bg-white bg-opacity-20 rounded-lg py-2 px-3 text-sm font-semibold hover:bg-opacity-30 transition-colors">
+                            ➕ Training planen
+                          </button>
+                        `}
+                      </div>
+
+                      <div class="bg-gradient-to-br from-purple-500 to-pink-600 rounded-2xl p-4 text-white shadow-lg">
+                        <div class="flex items-center justify-between mb-2">
+                          <h4 class="font-bold">Vorlage</h4>
+                          <div class="text-2xl">⚡</div>
+                        </div>
+                        <button onclick="app.showQuickTemplates()" class="w-full bg-white bg-opacity-20 rounded-lg py-2 px-3 text-sm font-semibold hover:bg-opacity-30 transition-colors">
+                          🔄 Letztes wiederholen
+                        </button>
+                      </div>
+                    </div>
+                `;
+            }
+
+            renderWeeklySummary(weekData) {
+                const completionRate = (weekData.completed / weekData.target) * 100;
+                const motivationalMessage = this.getMotivationalMessage(completionRate);
+
+                return `
+                    <div class="bg-white rounded-2xl shadow-lg p-4 mb-4">
+                      <div class="flex items-center justify-between mb-3">
+                        <h4 class="font-bold text-gray-800">Wochenbilanz</h4>
+                        <div class="text-2xl">${completionRate >= 100 ? '🏆' : completionRate >= 75 ? '🔥' : '💪'}</div>
+                      </div>
+                      <div class="grid grid-cols-3 gap-4 mb-4">
+                        <div class="text-center">
+                          <div class="text-2xl font-bold text-blue-600">${weekData.completed}</div>
+                          <div class="text-xs text-gray-500">Absolviert</div>
+                        </div>
+                        <div class="text-center">
+                          <div class="text-2xl font-bold text-gray-400">${weekData.target - weekData.completed}</div>
+                          <div class="text-xs text-gray-500">Verbleibend</div>
+                        </div>
+                        <div class="text-center">
+                          <div class="text-2xl font-bold text-green-600">${completionRate.toFixed(0)}%</div>
+                          <div class="text-xs text-gray-500">Erreicht</div>
+                        </div>
+                      </div>
+                      <div class="bg-gray-100 rounded-lg p-3">
+                        <div class="text-sm font-medium text-gray-800 mb-1">${motivationalMessage.title}</div>
+                        <div class="text-xs text-gray-600">${motivationalMessage.subtitle}</div>
+                      </div>
+                    </div>
+                `;
+            }
+
+            getMotivationalMessage(completionRate) {
+                if (completionRate >= 100) {
+                    return { title: 'Perfekte Woche! 🏆', subtitle: 'Du hast alle geplanten Trainings absolviert!' };
+                } else if (completionRate >= 75) {
+                    return { title: 'Fantastisch! 🔥', subtitle: 'Du bist auf einem super Weg!' };
+                } else if (completionRate >= 50) {
+                    return { title: 'Gut gemacht! 💪', subtitle: 'Bleib dran, du schaffst das!' };
+                }
+                return { title: 'Lass uns loslegen! 🚀', subtitle: 'Jedes Training bringt dich weiter!' };
+            }
+
+            renderEnhancedHeader(currentWeek, weekData) {
+                const streak = this.calculateStreak();
+                const weekProgress = (weekData.completed / weekData.target) * 100;
+                const monthStats = this.getMonthStats();
+
+                return `
+                    <div class="bg-gradient-to-br from-blue-600 via-indigo-600 to-purple-700 text-white relative overflow-hidden">
+                      <div class="absolute inset-0 opacity-10">
+                        <svg class="w-full h-full" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
+                          <defs><pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M 40 0 L 0 0 0 40" fill="none" stroke="white" stroke-width="1"/></pattern></defs>
+                          <rect width="100%" height="100%" fill="url(#grid)"/>
+                        </svg>
+                      </div>
+                      <div class="relative p-4">
+                        <div class="flex items-center justify-between mb-4">
+                          <div class="flex items-center">
+                            <div class="w-12 h-12 bg-white bg-opacity-20 rounded-full flex items-center justify-center mr-3">
+                              <span class="text-lg font-bold">${this.userData.name[0].toUpperCase()}</span>
+                            </div>
+                            <div>
+                              <h1 class="text-xl font-bold">Hi ${this.userData.name}! 💪</h1>
+                              <p class="text-blue-100 text-sm">Bereit für dein Training?</p>
+                            </div>
+                          </div>
+                          <button onclick="app.showSettings()" class="w-10 h-10 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
+                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+                          </button>
+                        </div>
+                        <div class="grid grid-cols-3 gap-3 mb-4">
+                          <div class="bg-white bg-opacity-15 backdrop-blur-sm rounded-xl p-3 text-center">
+                            <div class="text-2xl font-bold">${weekData.completed}</div>
+                            <div class="text-xs text-blue-100">Diese Woche</div>
+                          </div>
+                          <div class="bg-white bg-opacity-15 backdrop-blur-sm rounded-xl p-3 text-center">
+                            <div class="text-2xl font-bold">${streak}</div>
+                            <div class="text-xs text-blue-100">Tage Streak 🔥</div>
+                          </div>
+                          <div class="bg-white bg-opacity-15 backdrop-blur-sm rounded-xl p-3 text-center">
+                            <div class="text-2xl font-bold">${monthStats.total}</div>
+                            <div class="text-xs text-blue-100">Diesen Monat</div>
+                          </div>
+                        </div>
+                        <div class="bg-white bg-opacity-10 backdrop-blur-sm rounded-xl p-4">
+                          <div class="flex items-center justify-between mb-2">
+                            <span class="font-semibold">Woche ${currentWeek.split('-W')[1]} Progress</span>
+                            <span class="text-sm bg-white bg-opacity-20 px-2 py-1 rounded-full">${weekData.completed}/${weekData.target}</span>
+                          </div>
+                          <div class="w-full bg-white bg-opacity-20 rounded-full h-3 mb-2">
+                            <div class="bg-gradient-to-r from-green-400 to-emerald-400 h-3 rounded-full transition-all duration-700 shadow-lg" style="width: ${weekProgress}%"></div>
+                          </div>
+                          <div class="flex justify-between text-xs text-blue-100">
+                            <span>Ziel: ${weekData.target}x Training</span>
+                            <span>${weekProgress.toFixed(0)}% erreicht</span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                `;
+            }
+
+            renderAdvancedCalendar(currentWeek, weekData) {
+                const { start, end } = this.getWeekBounds(currentWeek);
+                const prevWeek = this.getPreviousWeek(currentWeek);
+                const nextWeek = this.getNextWeek(currentWeek);
+
+                return `
+                    <div class="p-4">
+                      <div class="bg-white rounded-2xl shadow-lg p-4 mb-4">
+                        <div class="flex items-center justify-between mb-4">
+                          <button onclick="app.navigateToWeek('${prevWeek}')" class="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center hover:bg-gray-200 transition-colors">
+                            <svg class="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+                          </button>
+                          <div class="text-center">
+                            <h3 class="text-lg font-bold text-gray-800">${start.getDate()}.${start.getMonth()+1} - ${end.getDate()}.${end.getMonth()+1}.${end.getFullYear()}</h3>
+                            <p class="text-sm text-gray-500">Kalenderwoche ${currentWeek.split('-W')[1]}</p>
+                          </div>
+                          <button onclick="app.navigateToWeek('${nextWeek}')" class="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center hover:bg-gray-200 transition-colors">
+                            <svg class="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                          </button>
+                        </div>
+                        <div class="grid grid-cols-7 gap-2">
+                          ${this.renderEnhancedCalendarDays(currentWeek, weekData)}
+                        </div>
+                      </div>
+
+                      ${this.renderQuickActions(currentWeek, weekData)}
+
+                    ${this.renderWeeklySummary(weekData)}
+                    </div>
+                `;
+            }
+
+            navigateToWeek(weekString) {
+                if (!this.weeklyData.weeks[weekString]) {
+                    const bounds = this.getWeekBounds(weekString);
+                    this.weeklyData.weeks[weekString] = {
+                        startDate: bounds.start.toISOString().split('T')[0],
+                        endDate: bounds.end.toISOString().split('T')[0],
+                        target: this.weeklyData.weeklyGoal,
+                        completed: 0,
+                        workouts: [],
+                        isWeekCompleted: false
+                    };
+                }
+                this.weeklyData.currentWeek = weekString;
+                this.saveWeeklyData();
+                this.render();
+            }
+
+            startTodayWorkout() {
+                const workout = this.getTodayWorkout();
+                if (workout) {
+                    this.selectedDate = workout.date;
+                    this.selectedDay = this.getWorkoutIndex(workout);
+                    this.currentView = 'day';
+                    this.render();
+                }
+            }
+
+            showQuickTemplates() {
+                alert('Template Auswahl folgt');
+            }
+
+            showSettings() {
+                alert('Einstellungen folgen');
+            }
+
             render() {
                 const app = document.getElementById('app');
 
@@ -1268,20 +1679,8 @@
 
                 return `
                     <div class="max-w-md mx-auto bg-gradient-to-br from-blue-50 to-indigo-100 min-h-screen">
-                        <div class="bg-white shadow-lg">
-                            <div class="p-4 bg-gradient-to-r from-blue-600 to-indigo-600 text-white">
-                                <h1 class="text-xl font-bold">📅 ${this.userData.name}'s Trainingskalender</h1>
-                                <p class="text-blue-100">Woche ${currentWeek.split('-W')[1]} • ${weekData.completed}/${weekData.target} Trainings</p>
-                                <div class="mt-2 bg-white bg-opacity-20 rounded-lg p-2">
-                                    <div class="w-full bg-white bg-opacity-30 rounded-full h-2">
-                                        <div class="bg-white h-2 rounded-full transition-all duration-500" style="width: ${(weekData.completed / weekData.target) * 100}%"></div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        ${this.renderWeekCalendar(currentWeek, weekData)}
-
+                        ${this.renderEnhancedHeader(currentWeek, weekData)}
+                        ${this.renderAdvancedCalendar(currentWeek, weekData)}
                         <div class="p-4">
                             <button onclick="localStorage.clear(); location.reload();" class="w-full text-xs text-blue-600 p-2 border border-blue-200 rounded-lg">
                                 🔄 Neuen Plan erstellen


### PR DESCRIPTION
## Summary
- add enhanced calendar styles
- implement new header, calendar, quick actions, and summary components
- include streak and month stats
- add navigation between weeks and workout stubs

## Testing
- `node -e "require('fs').readFileSync('custom-tracker.html')"`

------
https://chatgpt.com/codex/tasks/task_e_6870064783388323825609890a89ff73