### PR TITLE
Fix initialization errors and update VirtualDOM

### DIFF
--- a/index-new.html
+++ b/index-new.html
@@ -23,7 +23,7 @@
     <div id="app">
         <div class="loading-initial">
             <div class="text-center p-8">
-                <div class="text-4xl mb-4">\ud83e\udd13</div>
+                <div class="text-4xl mb-4">🧙‍♂️</div>
                 <div class="text-lg font-semibold">Neue Architektur wird geladen...</div>
             </div>
         </div>
@@ -31,8 +31,18 @@
 
     <!-- Load new architecture -->
     <script type="module">
-        import { App } from './src/core/App.js';
-        window.fitnessApp = new App();
+        try {
+            const module = await import('./src/core/App.js');
+            window.fitnessApp = new module.App();
+        } catch (error) {
+            console.error('App initialization failed:', error);
+            document.getElementById('app').innerHTML = `
+                <div class="p-8 text-center">
+                    <h2>Loading Error</h2>
+                    <pre>${error.message}</pre>
+                </div>
+            `;
+        }
     </script>
     <script>
         window.addEventListener('error', (event) => {

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -39,7 +39,7 @@ export class App {
       this.render();
     } catch (error) {
       console.error('App initialization failed:', error);
-      this.showError('App konnte nicht geladen werden');
+      this.showError('App konnte nicht geladen werden: ' + error.message);
     }
   }
 

--- a/src/core/Component.js
+++ b/src/core/Component.js
@@ -20,17 +20,22 @@ export class Component {
   }
 
   render() {
-    throw new Error('Component must implement render() method');
+    throw new Error(`Component ${this.constructor.name} must implement render() method`);
   }
 
   mount(container) {
-    this.lastVNode = this.render();
-    const temp = document.createElement('div');
-    VirtualDOM.render(this.lastVNode, temp);
-    this.element = temp.firstChild;
-    container.appendChild(this.element);
-    this.onMount();
-    return this.element;
+    try {
+      this.lastVNode = this.render();
+      const temp = document.createElement('div');
+      VirtualDOM.render(this.lastVNode, temp);
+      this.element = temp.firstChild;
+      container.appendChild(this.element);
+      this.onMount();
+      return this.element;
+    } catch (error) {
+      console.error('Component mount failed:', error);
+      throw error;
+    }
   }
 
   unmount() {

--- a/src/core/VirtualDOM.js
+++ b/src/core/VirtualDOM.js
@@ -4,13 +4,21 @@ export class VirtualDOM {
   }
 
   static render(vnode, container) {
+    if (!vnode) return;
     if (typeof vnode === 'string') {
       container.appendChild(document.createTextNode(vnode));
       return;
     }
+
+    if (!vnode.tag) {
+      console.warn('VNode missing tag:', vnode);
+      return;
+    }
+
     const element = document.createElement(vnode.tag);
-    Object.entries(vnode.props).forEach(([key, value]) => {
-      if (key.startsWith('on')) {
+    const props = vnode.props || {};
+    Object.entries(props).forEach(([key, value]) => {
+      if (key.startsWith('on') && typeof value === 'function') {
         element.addEventListener(key.slice(2).toLowerCase(), value);
       } else if (key === 'className') {
         element.className = value;
@@ -18,7 +26,8 @@ export class VirtualDOM {
         element.setAttribute(key, value);
       }
     });
-    vnode.children.forEach(child => this.render(child, element));
+
+    (vnode.children || []).forEach(child => this.render(child, element));
     container.appendChild(element);
   }
 


### PR DESCRIPTION
## Summary
- display wizard emoji correctly in **index-new.html**
- wrap dynamic app load in try/catch to show load errors
- surface init error messages in `App.init`
- improve error handling in `Component` lifecycle
- harden `VirtualDOM.render` for invalid nodes

## Testing
- `npm install --silent`
- `npx playwright test` *(fails: ReferenceError: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_6871194b62e483238db452e3869fb260