### PR TITLE
Improve constructor debugging

### DIFF
--- a/src/core/App.js
+++ b/src/core/App.js
@@ -8,20 +8,34 @@ import { CalendarView } from '../components/CalendarView/CalendarView.js';
 
 export class App {
   constructor() {
-    console.log('App constructor started');
-    this.eventBus = new EventBus();
-    this.currentView = 'setup';
-    this.components = new Map();
+    try {
+      console.log('App constructor started');
 
-    this.exerciseDatabase = null;
-    this.planGenerator = null;
-    this.weeklyDataManager = new WeeklyDataManager();
+      console.log('Creating EventBus...');
+      this.eventBus = new EventBus();
 
-    this.userData = null;
-    this.currentPlan = null;
+      console.log('Setting initial state...');
+      this.currentView = 'setup';
+      this.components = new Map();
+      this.exerciseDatabase = null;
+      this.planGenerator = null;
+      this.userData = null;
+      this.currentPlan = null;
 
-    console.log('App constructor completed, calling init()');
-    this.init();
+      console.log('Creating WeeklyDataManager...');
+      this.weeklyDataManager = new WeeklyDataManager();
+
+      console.log('App constructor completed, calling init()');
+      this.init();
+    } catch (error) {
+      console.error('App constructor failed:', error);
+      document.getElementById('app').innerHTML = `
+        <div class="p-8 text-center">
+          <h2 class="text-xl font-bold text-red-600 mb-4">Constructor Error</h2>
+          <pre>${error.message}\n${error.stack}</pre>
+        </div>
+      `;
+    }
   }
 
   async init() {

--- a/src/services/WeeklyDataManager.js
+++ b/src/services/WeeklyDataManager.js
@@ -2,7 +2,14 @@ import { load, save } from '../utils/StorageUtils.js';
 
 export class WeeklyDataManager {
   constructor() {
-    this.data = this.loadFromStorage();
+    try {
+      console.log('WeeklyDataManager constructor started');
+      this.data = this.loadFromStorage();
+      console.log('WeeklyDataManager constructor completed');
+    } catch (error) {
+      console.error('WeeklyDataManager constructor failed:', error);
+      throw error;
+    }
   }
 
   getCurrentWeek() {


### PR DESCRIPTION
## Summary
- make App constructor resilient to early errors
- add logging around WeeklyDataManager initialization

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node test/component.test.js`
- `node test/validation.test.js`
- `npx playwright test` *(fails: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68712070a6e48323a9ba7449e421338a