### PR TITLE
Add keyed diffing to VirtualDOM

### DIFF
--- a/src/core/VirtualDOM.js
+++ b/src/core/VirtualDOM.js
@@ -1,47 +1,74 @@
 export class VirtualDOM {
   static createElement(tag, props = {}, children = []) {
-    return { tag, props, children: children.flat() };
+    return { tag, props, children: children.flat().filter(Boolean) };
   }
 
   static render(vnode, container) {
     if (!vnode) return;
-    if (typeof vnode === 'string') {
-      container.appendChild(document.createTextNode(vnode));
+
+    // Text nodes
+    if (typeof vnode === 'string' || typeof vnode === 'number') {
+      container.appendChild(document.createTextNode(String(vnode)));
       return;
     }
 
-    const element = document.createElement(vnode.tag);
+    if (vnode.tag) {
+      const element = document.createElement(vnode.tag);
 
-    Object.entries(vnode.props || {}).forEach(([key, value]) => {
-      if (key.startsWith('on') && typeof value === 'function') {
-        element.addEventListener(key.slice(2).toLowerCase(), value);
-      } else if (key === 'className') {
-        element.className = value;
-      } else {
-        element.setAttribute(key, value);
-      }
-    });
+      // Set attributes and event listeners
+      Object.entries(vnode.props || {}).forEach(([key, value]) => {
+        if (key.startsWith('on') && typeof value === 'function') {
+          element.addEventListener(key.slice(2).toLowerCase(), value);
+        } else if (key === 'className') {
+          element.className = value;
+        } else if (key === 'style') {
+          element.setAttribute('style', value);
+        } else if (key === 'value') {
+          element.value = value;
+        } else if (key === 'disabled') {
+          element.disabled = value;
+        } else if (key === 'placeholder') {
+          element.placeholder = value;
+        } else if (key === 'type') {
+          element.type = value;
+        } else if (key === 'min' || key === 'max') {
+          element.setAttribute(key, value);
+        } else if (value !== null && value !== undefined) {
+          element.setAttribute(key, value);
+        }
+      });
 
-    (vnode.children || []).forEach(child => {
-      this.render(child, element);
-    });
+      // Render children
+      (vnode.children || []).forEach(child => {
+        this.render(child, element);
+      });
 
-    container.appendChild(element);
+      container.appendChild(element);
+      return element;
+    }
+
+    console.warn('Unknown vnode type:', vnode);
   }
 
   static diff(oldVNode, newVNode) {
     if (!oldVNode) return { type: 'CREATE', vnode: newVNode };
     if (!newVNode) return { type: 'REMOVE' };
     if (typeof oldVNode !== typeof newVNode) return { type: 'REPLACE', vnode: newVNode };
-    if (typeof oldVNode === 'string') {
-      return oldVNode !== newVNode ? { type: 'REPLACE', vnode: newVNode } : null;
+    if (typeof oldVNode === 'string' || typeof oldVNode === 'number') {
+      return String(oldVNode) !== String(newVNode) ? { type: 'REPLACE', vnode: newVNode } : null;
     }
     if (oldVNode.tag !== newVNode.tag) return { type: 'REPLACE', vnode: newVNode };
-    return { type: 'UPDATE', props: this.diffProps(oldVNode.props, newVNode.props) };
+
+    return {
+      type: 'UPDATE',
+      props: this.diffProps(oldVNode.props, newVNode.props),
+      children: this.diffChildren(oldVNode.children, newVNode.children)
+    };
   }
 
-  static diffProps(oldProps, newProps) {
+  static diffProps(oldProps = {}, newProps = {}) {
     const patches = {};
+
     Object.keys(oldProps).forEach(key => {
       if (!(key in newProps)) {
         patches[key] = null;
@@ -49,10 +76,75 @@ export class VirtualDOM {
         patches[key] = newProps[key];
       }
     });
+
     Object.keys(newProps).forEach(key => {
-      if (!(key in oldProps)) patches[key] = newProps[key];
+      if (!(key in oldProps)) {
+        patches[key] = newProps[key];
+      }
     });
+
     return Object.keys(patches).length > 0 ? patches : null;
+  }
+
+  static diffChildren(oldChildren = [], newChildren = []) {
+    const patches = [];
+
+    const oldKeyed = {};
+    const newKeyed = {};
+
+    oldChildren.forEach((child, index) => {
+      const key = child && child.props && child.props.key;
+      if (key !== undefined) oldKeyed[key] = { child, index };
+    });
+
+    newChildren.forEach((child, index) => {
+      const key = child && child.props && child.props.key;
+      if (key !== undefined) newKeyed[key] = { child, index };
+    });
+
+    const hasKeys = Object.keys(oldKeyed).length > 0 || Object.keys(newKeyed).length > 0;
+
+    if (hasKeys) {
+      // Removals
+      Object.entries(oldKeyed).forEach(([key, { index }]) => {
+        if (!(key in newKeyed)) {
+          patches.push({ index, patch: { type: 'REMOVE' } });
+        }
+      });
+
+      // Creates and moves/updates
+      newChildren.forEach((newChild, newIndex) => {
+        const key = newChild && newChild.props && newChild.props.key;
+        if (key !== undefined) {
+          const oldRecord = oldKeyed[key];
+          if (!oldRecord) {
+            patches.push({ index: newIndex, patch: { type: 'CREATE', vnode: newChild } });
+          } else {
+            const patch = this.diff(oldRecord.child, newChild);
+            if (patch) patches.push({ index: newIndex, patch });
+            if (oldRecord.index !== newIndex) {
+              patches.push({ index: newIndex, patch: { type: 'MOVE', from: oldRecord.index } });
+            }
+          }
+        } else {
+          const patch = this.diff(oldChildren[newIndex], newChild);
+          if (patch) patches.push({ index: newIndex, patch });
+        }
+      });
+
+      return patches.length > 0 ? patches : null;
+    }
+
+    // Non-keyed fallback
+    const maxLength = Math.max(oldChildren.length, newChildren.length);
+    for (let i = 0; i < maxLength; i++) {
+      const patch = this.diff(oldChildren[i], newChildren[i]);
+      if (patch) {
+        patches.push({ index: i, patch });
+      }
+    }
+
+    return patches.length > 0 ? patches : null;
   }
 }
 

--- a/test/virtualdom.test.js
+++ b/test/virtualdom.test.js
@@ -1,0 +1,41 @@
+import assert from 'assert';
+import { VirtualDOM } from '../src/core/VirtualDOM.js';
+
+const li = (k, t) => VirtualDOM.createElement('li', { key: k }, [t]);
+
+// Reordering
+const oldList = VirtualDOM.createElement('ul', {}, [
+  li('a', 'A'),
+  li('b', 'B'),
+  li('c', 'C')
+]);
+
+const newList = VirtualDOM.createElement('ul', {}, [
+  li('b', 'B'),
+  li('a', 'A'),
+  li('c', 'C')
+]);
+
+const diff1 = VirtualDOM.diff(oldList, newList);
+assert(Array.isArray(diff1.children));
+const moves = diff1.children.filter(p => p.patch && p.patch.type === 'MOVE');
+assert.strictEqual(moves.length, 2);
+
+// Removal and creation
+const oldList2 = VirtualDOM.createElement('ul', {}, [
+  li('a', 'A'),
+  li('b', 'B')
+]);
+
+const newList2 = VirtualDOM.createElement('ul', {}, [
+  li('b', 'B'),
+  li('c', 'C')
+]);
+
+const diff2 = VirtualDOM.diff(oldList2, newList2);
+const removes = diff2.children.filter(p => p.patch && p.patch.type === 'REMOVE');
+const creates = diff2.children.filter(p => p.patch && p.patch.type === 'CREATE');
+assert.strictEqual(removes.length, 1);
+assert.strictEqual(creates.length, 1);
+
+console.log('virtualdom keyed diff tests passed');


### PR DESCRIPTION
## Summary
- enhance `VirtualDOM` with full render helpers and keyed diffing
- add `diffChildren` to support reordering and keyed nodes
- create tests covering keyed diff logic

## Testing
- `node test/component.test.js && node test/validation.test.js && node test/virtualdom.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687132fb0ddc8323880aea22d64b3c72