### PR TITLE
Fix loading screen stuck issue

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,6 +1,6 @@
-const { devices } = require('@playwright/test');
+import { devices } from '@playwright/test';
 
-module.exports = {
+export default {
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
     { name: 'firefox', use: { ...devices['Desktop Firefox'] } },

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -125,6 +125,8 @@ export class App {
   render() {
     console.log('🎨 Rendering view:', this.currentView);
     const container = document.getElementById('app');
+    // Clear previous content (e.g., initial loading screen)
+    container.innerHTML = '';
 
     this.components.forEach(c => c.unmount());
     this.components.clear();


### PR DESCRIPTION
## Summary
- clear the container when rendering new views
- switch Playwright config to ES module syntax

## Testing
- `node test/component.test.js`
- `node test/validation.test.js`
- `node test/virtualdom.test.js`
- `npx playwright test` *(fails: executable download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68713505eb808323bd09931fb5edd02d