### PR TITLE
Apply CSS fix via direct DOM manipulation

### DIFF
--- a/src/components/SetupWizard/SetupWizard.js
+++ b/src/components/SetupWizard/SetupWizard.js
@@ -1,4 +1,5 @@
 import { Component } from '../../core/Component.js';
+import { VirtualDOM } from '../../core/VirtualDOM.js';
 import { WelcomeStep } from './steps/WelcomeStep.js';
 // Placeholder imports for remaining steps
 import { GoalsStep } from './steps/GoalsStep.js';
@@ -46,6 +47,100 @@ export class SetupWizard extends Component {
       this.renderStepContent(currentStepComponent),
       this.renderNavigation()
     ]);
+  }
+
+  onMount() {
+    // Force apply CSS classes after mount
+    this.applyCSSFix();
+  }
+
+  applyCSSFix() {
+    if (!this.element) return;
+
+    // Apply CSS directly to DOM elements after a short delay
+    setTimeout(() => {
+      const wizard = this.element;
+      if (wizard) {
+        // Header styling
+        const header = wizard.querySelector('.setup-wizard') || wizard;
+        if (header) {
+          header.style.cssText = `
+          max-width: 28rem;
+          margin: 0 auto;
+          background: white;
+          min-height: 100vh;
+        `;
+        }
+
+        // Header gradient
+        const headerDiv = wizard.querySelector('[class*="gradient"]') || wizard.firstElementChild;
+        if (headerDiv) {
+          headerDiv.style.cssText = `
+          padding: 1rem;
+          background: linear-gradient(to right, #2563eb, #4f46e5);
+          color: white;
+        `;
+        }
+
+        // Content area
+        const content = wizard.querySelector('[class*="p-6"]');
+        if (content) {
+          content.style.cssText = `
+          padding: 1.5rem;
+        `;
+        }
+
+        // Input fields
+        const inputs = wizard.querySelectorAll('input');
+        inputs.forEach(input => {
+          input.style.cssText = `
+          width: 100%;
+          padding: 0.75rem;
+          border: 1px solid #d1d5db;
+          border-radius: 0.5rem;
+          margin-bottom: 1rem;
+        `;
+        });
+
+        // Labels
+        const labels = wizard.querySelectorAll('label');
+        labels.forEach(label => {
+          label.style.cssText = `
+          display: block;
+          font-size: 0.875rem;
+          font-weight: 500;
+          color: #374151;
+          margin-bottom: 0.5rem;
+        `;
+        });
+
+        // Buttons
+        const buttons = wizard.querySelectorAll('button');
+        buttons.forEach(button => {
+          if (button.disabled) {
+            button.style.cssText = `
+            flex: 1;
+            padding: 0.75rem;
+            font-weight: 600;
+            border-radius: 0.5rem;
+            background: #d1d5db;
+            color: #6b7280;
+            cursor: not-allowed;
+          `;
+          } else {
+            button.style.cssText = `
+            flex: 1;
+            padding: 0.75rem;
+            font-weight: 600;
+            border-radius: 0.5rem;
+            background: linear-gradient(to right, #2563eb, #4f46e5);
+            color: white;
+            cursor: pointer;
+          `;
+          }
+        });
+      }
+    }, 50);
   }
 
   renderHeader() {
@@ -141,6 +236,20 @@ export class SetupWizard extends Component {
   previousStep() {
     if (this.state.currentStep > 1) {
       this.setState({ currentStep: this.state.currentStep - 1 });
+    }
+  }
+
+  update() {
+    if (this.element) {
+      const newVNode = this.render();
+      const patches = VirtualDOM.diff(this.lastVNode, newVNode);
+      if (patches) {
+        this.applyPatches(this.element, patches);
+      }
+      this.lastVNode = newVNode;
+
+      // Reapply CSS after DOM update
+      this.applyCSSFix();
     }
   }
 

--- a/src/core/VirtualDOM.js
+++ b/src/core/VirtualDOM.js
@@ -15,16 +15,27 @@ export class VirtualDOM {
     if (vnode.tag) {
       const element = document.createElement(vnode.tag);
 
-      // Set attributes and event listeners
+      // Set attributes and event listeners with CSS persistence
       Object.entries(vnode.props || {}).forEach(([key, value]) => {
         if (key.startsWith('on') && typeof value === 'function') {
-          element.addEventListener(key.slice(2).toLowerCase(), value);
+          const eventName = key.slice(2).toLowerCase();
+          element.addEventListener(eventName, value);
         } else if (key === 'className') {
           element.className = value;
-          // Ensure class attribute is also set for compatibility
-          if (value) element.setAttribute('class', value);
+          element.setAttribute('class', value);
+          // Force CSS recomputation
+          element.setAttribute('data-css-applied', 'true');
         } else if (key === 'style') {
           element.setAttribute('style', value);
+          if (value) {
+            const styles = value.split(';');
+            styles.forEach(style => {
+              const [prop, val] = style.split(':').map(s => s.trim());
+              if (prop && val) {
+                element.style[prop] = val;
+              }
+            });
+          }
         } else if (key === 'value') {
           element.value = value;
         } else if (key === 'disabled') {


### PR DESCRIPTION
## Summary
- force CSS classes after SetupWizard mounts
- ensure SetupWizard reapplies CSS on updates
- preserve style attributes when rendering virtual DOM

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6871758b2cb083238eb447c5da987107