### PR TITLE
Fix props handling in setup steps

### DIFF
--- a/src/components/SetupWizard/steps/EquipmentStep.js
+++ b/src/components/SetupWizard/steps/EquipmentStep.js
@@ -1,7 +1,7 @@
 import { Component } from '../../../core/Component.js';
 
 export class EquipmentStep extends Component {
-  constructor(props) {
+  constructor(props = {}) {
     super(props);
     this.userData = props.userData || {};
     this.handlers = props.handlers || {};

--- a/src/components/SetupWizard/steps/ExperienceStep.js
+++ b/src/components/SetupWizard/steps/ExperienceStep.js
@@ -1,7 +1,7 @@
 import { Component } from '../../../core/Component.js';
 
 export class ExperienceStep extends Component {
-  constructor(props) {
+  constructor(props = {}) {
     super(props);
     this.userData = props.userData || {};
     this.handlers = props.handlers || {};

--- a/src/components/SetupWizard/steps/FocusStep.js
+++ b/src/components/SetupWizard/steps/FocusStep.js
@@ -1,7 +1,7 @@
 import { Component } from '../../../core/Component.js';
 
 export class FocusStep extends Component {
-  constructor(props) {
+  constructor(props = {}) {
     super(props);
     this.userData = props.userData || {};
     this.handlers = props.handlers || {};

--- a/src/components/SetupWizard/steps/GoalsStep.js
+++ b/src/components/SetupWizard/steps/GoalsStep.js
@@ -1,7 +1,7 @@
 import { Component } from '../../../core/Component.js';
 
 export class GoalsStep extends Component {
-  constructor(props) {
+  constructor(props = {}) {
     super(props);
     this.userData = props.userData || {};
     this.handlers = props.handlers || {};

--- a/src/components/SetupWizard/steps/ScheduleStep.js
+++ b/src/components/SetupWizard/steps/ScheduleStep.js
@@ -1,7 +1,7 @@
 import { Component } from '../../../core/Component.js';
 
 export class ScheduleStep extends Component {
-  constructor(props) {
+  constructor(props = {}) {
     super(props);
     this.userData = props.userData || {};
     this.handlers = props.handlers || {};

--- a/src/components/SetupWizard/steps/SummaryStep.js
+++ b/src/components/SetupWizard/steps/SummaryStep.js
@@ -1,7 +1,7 @@
 import { Component } from '../../../core/Component.js';
 
 export class SummaryStep extends Component {
-  constructor(props) {
+  constructor(props = {}) {
     super(props);
     this.userData = props.userData || {};
   }

--- a/src/components/SetupWizard/steps/WelcomeStep.js
+++ b/src/components/SetupWizard/steps/WelcomeStep.js
@@ -1,7 +1,7 @@
 import { Component } from '../../../core/Component.js';
 
 export class WelcomeStep extends Component {
-  constructor(props) {
+  constructor(props = {}) {
     super(props);
     this.userData = props.userData || {};
     this.handlers = props.handlers || {};


### PR DESCRIPTION
## Summary
- prevent errors in SetupWizard step constructors when no props are passed

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx playwright test` *(fails to install playwright)*

------
https://chatgpt.com/codex/tasks/task_e_687179fd9ca083239566f6a399059907