### PR TITLE
Fix undefined userData in WelcomeStep

### DIFF
--- a/src/components/SetupWizard/steps/WelcomeStep.js
+++ b/src/components/SetupWizard/steps/WelcomeStep.js
@@ -1,5 +1,5 @@
 // Pure Function - NO CLASS!
-export function WelcomeStep(userData, handlers) {
+export function WelcomeStep(userData = {}, handlers = {}) {
   return {
     tag: 'div',
     props: { className: 'step' },


### PR DESCRIPTION
## Summary
- provide default parameters in WelcomeStep so missing data doesn't crash the wizard

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6872523595f8832382134aa155b2ea34