### PR TITLE
Fix wizard navigation disabled state

### DIFF
--- a/src/components/SetupWizard/SetupWizard.js
+++ b/src/components/SetupWizard/SetupWizard.js
@@ -1,5 +1,11 @@
 import { Component } from '../../core/Component.js';
 import { WelcomeStep } from './steps/WelcomeStep.js';
+import { GoalsStep } from './steps/GoalsStep.js';
+import { ExperienceStep } from './steps/ExperienceStep.js';
+import { EquipmentStep } from './steps/EquipmentStep.js';
+import { FocusStep } from './steps/FocusStep.js';
+import { ScheduleStep } from './steps/ScheduleStep.js';
+import { SummaryStep } from './steps/SummaryStep.js';
 
 export class SetupWizard extends Component {
   constructor(props) {
@@ -54,6 +60,24 @@ export class SetupWizard extends Component {
       case 1:
         stepVNode = WelcomeStep(userData, handlers);
         break;
+      case 2:
+        stepVNode = new GoalsStep({ userData, handlers }).render();
+        break;
+      case 3:
+        stepVNode = new ExperienceStep({ userData, handlers }).render();
+        break;
+      case 4:
+        stepVNode = new EquipmentStep({ userData, handlers }).render();
+        break;
+      case 5:
+        stepVNode = new FocusStep({ userData, handlers }).render();
+        break;
+      case 6:
+        stepVNode = new ScheduleStep({ userData, handlers }).render();
+        break;
+      case 7:
+        stepVNode = new SummaryStep({ userData }).render();
+        break;
       default:
         stepVNode = {
           tag: 'div',
@@ -97,9 +121,14 @@ export class SetupWizard extends Component {
   }
 
   updateUserData(key, value) {
+    console.log('Updating:', key, value);
     this.setState({
       userData: { ...this.state.userData, [key]: value }
     });
+    setTimeout(() => {
+      console.log('New state:', this.state.userData);
+      console.log('Can proceed:', this.validateCurrentStep());
+    }, 0);
   }
 
   toggleArrayItem(arrayKey, item) {

--- a/src/core/Component.js
+++ b/src/core/Component.js
@@ -77,7 +77,23 @@ export class Component {
       case 'UPDATE':
         if (patch.props) {
           Object.entries(patch.props).forEach(([key, value]) => {
-            if (value === null) {
+            if (key === 'disabled') {
+              if (value) {
+                element.setAttribute('disabled', 'disabled');
+                element.disabled = true;
+              } else {
+                element.removeAttribute('disabled');
+                element.disabled = false;
+              }
+            } else if (key === 'className') {
+              if (value === null) {
+                element.removeAttribute('class');
+              } else {
+                element.className = value;
+              }
+            } else if (key === 'value') {
+              element.value = value ?? '';
+            } else if (value === null) {
               element.removeAttribute(key);
             } else {
               element.setAttribute(key, value);


### PR DESCRIPTION
## Summary
- handle boolean disabled attribute updates in `Component`
- wire up all SetupWizard steps
- log state changes for debugging

## Testing
- `node test/virtualdom.test.js && node test/component.test.js && node test/validation.test.js`
- `npx playwright test test/integration/setup-flow.test.js` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687257e14aa483239b7b94b7727f9c0c