### PR TITLE
Fix VirtualDOM patch failure with full re-render

### DIFF
--- a/src/core/Component.js
+++ b/src/core/Component.js
@@ -47,13 +47,15 @@ export class Component {
   }
 
   update() {
-    if (this.element) {
-      const newVNode = this.render();
-      const patches = VirtualDOM.diff(this.lastVNode, newVNode);
-      if (patches) {
-        this.applyPatches(this.element, patches);
-      }
-      this.lastVNode = newVNode;
+    if (this.element && this.element.parentNode) {
+      const parent = this.element.parentNode;
+      parent.removeChild(this.element);
+      this.lastVNode = this.render();
+      const temp = document.createElement('div');
+      VirtualDOM.render(this.lastVNode, temp);
+      this.element = temp.firstChild;
+      parent.appendChild(this.element);
+      console.log(`${this.constructor.name} re-rendered`);
     }
   }
 


### PR DESCRIPTION
## Summary
- re-render components completely on state updates
- log when a component re-renders

## Testing
- `node test/component.test.js`
- `node test/virtualdom.test.js`
- `node test/validation.test.js`
- `npx playwright test test/integration/setup-flow.test.js` *(fails: Host system is missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687269e7b240832395748df5de109df9