### PR TITLE
Add detailed equipment options

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -365,6 +365,51 @@
   font-weight: 600;
 }
 
+/* Equipment Selection Grid */
+.equipment-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+  margin: 20px 0;
+}
+
+.equipment-card {
+  background: white;
+  border: 2px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px 8px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-height: 80px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.equipment-card:hover {
+  border-color: #3b82f6;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.15);
+}
+
+.equipment-card.selected {
+  border-color: #3b82f6;
+  background: #eff6ff;
+  color: #1e40af;
+}
+
+.equipment-icon {
+  font-size: 24px;
+  margin-bottom: 4px;
+}
+
+.equipment-name {
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
 /* Button Styles */
 .btn {
   padding: 0.75rem 1.5rem;

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -284,17 +284,36 @@ export class App {
 
   generateStep4HTML() {
     const equipment = window.appState.userData.equipment || [];
-    const equipmentOptions = ['Eigengewicht', 'Kurzhanteln', 'Langhanteln', 'Gym-Geräte'];
+    const equipmentOptions = [
+      { id: 'Eigengewicht', icon: '🤸‍♂️', title: 'Bodyweight' },
+      { id: 'Kurzhanteln', icon: '🏋️‍♂️', title: 'Dumbbells' },
+      { id: 'Langhantel', icon: '🏋️‍♀️', title: 'Barbell' },
+      { id: 'Kettlebell', icon: '⚫', title: 'Kettlebell' },
+      { id: 'Widerstandsbänder', icon: '🟠', title: 'Resistance Bands' },
+      { id: 'Schlingentrainer', icon: '🔗', title: 'TRX' },
+      { id: 'Trainingsmatte', icon: '🟫', title: 'Exercise Mat' },
+      { id: 'Gewichtsscheiben', icon: '⚪', title: 'Weight Plates' },
+      { id: 'Klimmzugstange', icon: '🚪', title: 'Pull-up Bar' },
+      { id: 'Medizinball', icon: '⚽', title: 'Medicine Ball' },
+      { id: 'Gymnastikball', icon: '🔵', title: 'Exercise Ball' },
+      { id: 'Springseil', icon: '➰', title: 'Jump Rope' },
+      { id: 'Resistance Loops', icon: '🟡', title: 'Mini Bands' },
+      { id: 'Liegestützgriffe', icon: '📐', title: 'Push-up Handles' },
+      { id: 'Ab Wheel', icon: '🛞', title: 'Ab Roller' }
+    ];
+
     return `
       <div class="step">
         <div class="step__emoji">🏋️</div>
         <h2 class="step__title">Welche Ausrüstung hast du?</h2>
-        ${equipmentOptions.map(eq => `
-          <button class="goal-button ${equipment.includes(eq) ? 'goal-button--selected' : ''}"
-                  onclick="window.toggleArrayItem('userData.equipment', '${eq}')">
-            ${eq}
-          </button>
-        `).join('')}
+        <div class="equipment-grid">
+          ${equipmentOptions.map(eq => `
+            <div class="equipment-card ${equipment.includes(eq.id) ? 'selected' : ''}" onclick="window.toggleArrayItem('userData.equipment', '${eq.id}')">
+              <div class="equipment-icon">${eq.icon}</div>
+              <div class="equipment-name">${eq.title}</div>
+            </div>
+          `).join('')}
+        </div>
       </div>
     `;
   }

--- a/src/services/WorkoutPlanGenerator.js
+++ b/src/services/WorkoutPlanGenerator.js
@@ -80,7 +80,21 @@ export class WorkoutPlanGenerator {
       'Eigengewicht': 'Eigengewicht',
       'Kurzhanteln': 'Kurzhanteln',
       'Langhanteln': 'Langhanteln',
-      'Gym-Ger\u00e4te': 'Gym-Ger\u00e4te'
+      'Gym-Ger\u00e4te': 'Gym-Ger\u00e4te',
+
+      'Langhantel': 'Langhanteln',
+      'Kettlebell': 'Kurzhanteln',
+      'Widerstandsbänder': 'Eigengewicht',
+      'Schlingentrainer': 'Eigengewicht',
+      'Trainingsmatte': 'Eigengewicht',
+      'Gewichtsscheiben': 'Langhanteln',
+      'Klimmzugstange': 'Eigengewicht',
+      'Medizinball': 'Kurzhanteln',
+      'Gymnastikball': 'Gym-Ger\u00e4te',
+      'Springseil': 'Eigengewicht',
+      'Resistance Loops': 'Eigengewicht',
+      'Liegest\u00fctzgriffe': 'Eigengewicht',
+      'Ab Wheel': 'Eigengewicht'
     };
     return mapping[equipment];
   }


### PR DESCRIPTION
## Summary
- expand equipment selection in setup wizard to 15 items
- add responsive grid styling for equipment cards
- map new equipment ids to existing workout categories

## Testing
- `npx playwright install` *(fails: domain blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68847c40756c83238505d20b7b9b6cdc