### PR TITLE
Fix CSS cascade & unify cache busting

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -899,15 +899,6 @@
   padding: 20px 0;
 }
 
-.training-card {
-  background: white;
-  border-radius: 16px;
-  padding: 24px;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.1);
-  transition: all 0.3s ease;
-  min-height: 180px;
-  cursor: pointer;
-}
 
 .training-card:hover:not(.completed) {
   transform: translateY(-4px);
@@ -980,6 +971,12 @@
   background: linear-gradient(90deg, #ff6b6b, #feca57, #48dbfb, #ff9ff3);
   background-size: 300% 300%;
   animation: gradient 3s ease infinite;
+}
+
+@keyframes gradient {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
 }
 
 .training-card:hover {
@@ -1138,7 +1135,7 @@
 }
 
 /* Training type themes */
-.theme-push { background: linear-gradient(135deg, #ff9a9e, #fecfef); }
-.theme-pull { background: linear-gradient(135deg, #667eea, #764ba2); }
-.theme-legs { background: linear-gradient(135deg, #11998e, #38ef7d); }
-.theme-cardio { background: linear-gradient(135deg, #ffecd2, #fcb69f); }
+.training-card.theme-push { background: linear-gradient(135deg, #ff9a9e, #fecfef) !important; }
+.training-card.theme-pull { background: linear-gradient(135deg, #667eea, #764ba2) !important; }
+.training-card.theme-legs { background: linear-gradient(135deg, #11998e, #38ef7d) !important; }
+.training-card.theme-cardio { background: linear-gradient(135deg, #ffecd2, #fcb69f) !important; }

--- a/index.html
+++ b/index.html
@@ -4,8 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>\uD83C\uDFCB\uFE0F Fitness Tracker - New Architecture</title>
-  <link rel="stylesheet" href="css/theme.css?v=20250726">
-  <link rel="stylesheet" href="css/app-responsive.css?v=20250726">
+  <script>
+    window.CACHE_VERSION = '20250726-' + Date.now();
+    ['css/theme.css', 'css/app-responsive.css'].forEach(file => {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = `${file}?v=${window.CACHE_VERSION}`;
+      document.head.appendChild(link);
+    });
+  </script>
   <style>
     body {
       margin: 0;
@@ -18,11 +25,10 @@
   <div id="app"></div>
   
   <script type="module">
-    import { App } from './src/core/App.js?v=20250726';
-
-    // Create app instance
-    const app = new App();
-    console.log('App instance created');
+    import(`./src/core/App.js?v=${window.CACHE_VERSION}`).then(({ App }) => {
+      const app = new App();
+      console.log('App instance created');
+    });
   </script>
 </body>
 </html>

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -224,6 +224,7 @@ window.initializeAppState = function() {
 export class App {
   constructor() {
     console.log('🚀 App constructor STARTED - Version: 2024-07-11-18:15');
+    this.forceCacheRefresh();
     window.initializeAppState();
     window.app = this;
     this.eventBus = new EventBus();
@@ -1063,6 +1064,21 @@ export class App {
 
   isWorkoutCompleted(dateStr, weekData) {
     return weekData.workouts.some(w => w.date === dateStr && w.isCompleted);
+  }
+
+  forceCacheRefresh() {
+    if ('serviceWorker' in navigator && 'caches' in window) {
+      caches.keys().then(cacheNames => {
+        return Promise.all(
+          cacheNames.map(cacheName => {
+            if (cacheName.startsWith('fitness-tracker-v')) {
+              console.log('Deleting old cache:', cacheName);
+              return caches.delete(cacheName);
+            }
+          })
+        );
+      });
+    }
   }
 
   saveToLocalStorage() {

--- a/sw.js
+++ b/sw.js
@@ -1,11 +1,14 @@
-const CACHE_NAME = 'fitness-tracker-v1.0.4';
+const CACHE_VERSION = '20250726-' + Date.now();
+const CACHE_NAME = 'fitness-tracker-v' + CACHE_VERSION;
 const urlsToCache = [
   './',
   './index.html',
   './archive/benni-specialized.html',
   './css/tailwind.css',
   './manifest.json',
-  './src/core/App.js?v=20250726'
+  `./css/theme.css?v=${CACHE_VERSION}`,
+  `./css/app-responsive.css?v=${CACHE_VERSION}`,
+  `./src/core/App.js?v=${CACHE_VERSION}`
 ];
 
 // Installation des Service Workers
@@ -31,7 +34,7 @@ self.addEventListener('activate', event => {
     caches.keys().then(cacheNames => {
       return Promise.all(
         cacheNames.map(cacheName => {
-          if (cacheName !== CACHE_NAME) {
+          if (cacheName.startsWith('fitness-tracker-v') && cacheName !== CACHE_NAME) {
             console.log('Service Worker: Deleting old cache:', cacheName);
             return caches.delete(cacheName);
           }


### PR DESCRIPTION
## Summary
- clean up `training-card` styles
- add gradient animation and themed variants
- inject cache-busting timestamp into HTML
- refresh caches from the app and service worker

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6884cad7758c83238c7f3e1455834af3