### PR TITLE
Fix training card completed state

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -1027,6 +1027,7 @@
   pointer-events: none;
   background: #f8fafc !important;
   color: #6b7280 !important;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.1) !important;
 }
 
 .exercise-item {


### PR DESCRIPTION
## Summary
- tweak `.training-card.completed` so completed cards retain box-shadow

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6884d21a29c883239e53b06b47f1940e