### PR TITLE
Remove duplicate training card style and bump cache

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -1027,7 +1027,6 @@
   pointer-events: none;
   background: #f8fafc !important;
   color: #6b7280 !important;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.1) !important;
 }
 
 .exercise-item {
@@ -1176,7 +1175,7 @@
 }
 
 /* Training type themes */
-.training-card.theme-push:not(.completed)  { background: linear-gradient(135deg, #ff9a9e, #fecfef) !important; }
-.training-card.theme-pull:not(.completed)  { background: linear-gradient(135deg, #667eea, #764ba2) !important; }
-.training-card.theme-legs:not(.completed)  { background: linear-gradient(135deg, #11998e, #38ef7d) !important; }
-.training-card.theme-cardio:not(.completed) { background: linear-gradient(135deg, #ffecd2, #fcb69f) !important; }
+.training-card.theme-push:not(.completed)  { background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%) !important; }
+.training-card.theme-pull:not(.completed)  { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important; }
+.training-card.theme-legs:not(.completed)  { background: linear-gradient(135deg, #11998e 0%, #38ef7d 100%) !important; }
+.training-card.theme-cardio:not(.completed) { background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%) !important; }

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>\uD83C\uDFCB\uFE0F Fitness Tracker - New Architecture</title>
   <script>
-    window.CACHE_VERSION = '20250726-' + Date.now();
+    window.CACHE_VERSION = '20250726-132608';
     ['css/theme.css', 'css/app-responsive.css'].forEach(file => {
       const link = document.createElement('link');
       link.rel = 'stylesheet';

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '20250726-' + Date.now();
+const CACHE_VERSION = '20250726-132608';
 const CACHE_NAME = 'fitness-tracker-v' + CACHE_VERSION;
 const urlsToCache = [
   './',


### PR DESCRIPTION
## Summary
- cleanup CSS and remove basic `.training-card` leftovers
- use gradients with explicit color stops for theme classes
- bump cache busting versions in HTML and service worker

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6884d6e392f083238259fb850622eca4