### PR TITLE
Fix setup to use generatePlan

### DIFF
--- a/src/services/WorkoutPlanGenerator.js
+++ b/src/services/WorkoutPlanGenerator.js
@@ -5,6 +5,11 @@ export class WorkoutPlanGenerator {
         this.exerciseManager = new ExerciseManager();
     }
 
+    // Compatibility wrapper for older code paths
+    async generatePlan(userData) {
+        return this.generateTrainingPool(userData);
+    }
+
     async generateTrainingPool(userData) {
         await this.exerciseManager.loadExercises();
         const { equipment, frequency, experience } = userData;


### PR DESCRIPTION
## Summary
- add backwards-compatible `generatePlan` alias in `WorkoutPlanGenerator`
- call `generatePlan` when completing setup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6884db19f1208323818e05ba12baacbb